### PR TITLE
feat: Closing behaviour of mobile NavMenu

### DIFF
--- a/components/NavMenu/NavMenu.jsx
+++ b/components/NavMenu/NavMenu.jsx
@@ -1,4 +1,5 @@
 import { useRouter } from 'next/router';
+import useClickOutside from '../../hooks/useClickOutside';
 
 // components
 import Link from 'next/link';
@@ -17,12 +18,19 @@ const NAV_LINKS = [
  * Displayed as navigation drawer in mobile view
  * Otherwise displayed as regular top navigation bar
  */
-const NavMenu = ({ isOpen }) => {
+const NavMenu = ({ isOpen, closeNavMenu }) => {
   const router = useRouter();
   const currentRoute = router.pathname;
 
+  // Close mobile NavMenu on click outside of component
+  const menuRef = useClickOutside(closeNavMenu, 'nav-menu');
+
   return (
-    <div className={styles['nav-menu-wrapper']} aria-expanded={isOpen}>
+    <div
+      ref={menuRef}
+      className={styles['nav-menu-wrapper']}
+      aria-expanded={isOpen}
+    >
       <nav className={styles['nav-menu']} aria-expanded={isOpen}>
         {NAV_LINKS.map((link, index) => (
           <Link key={index} href={link.path}>
@@ -30,6 +38,7 @@ const NavMenu = ({ isOpen }) => {
               className={
                 currentRoute === link.path ? styles['active-nav-link'] : ''
               }
+              onClick={closeNavMenu}
             >
               {link.name}
             </a>

--- a/components/NavRoot/NavRoot.jsx
+++ b/components/NavRoot/NavRoot.jsx
@@ -4,6 +4,9 @@ import { useState } from 'react';
 import NavMenu from '../NavMenu/NavMenu';
 import ResponsiveNavToggle from '../ResponsiveNavToggle/ResponsiveNavToggle';
 
+// utils
+import { handleSwiperNoSwiping } from '../../utils/swiper';
+
 /**
  * Navigation toggle state & handlers defined here
  * Conditionally renders mobile or desktop navigation
@@ -12,12 +15,22 @@ const NavRoot = () => {
   const [isOpen, setIsOpen] = useState(false);
 
   const handleMenuToggle = (e) => {
+    handleSwiperNoSwiping('toggle');
     setIsOpen((prevState) => !prevState);
+  };
+
+  const closeNavMenu = () => {
+    handleSwiperNoSwiping('remove');
+    setIsOpen(false);
   };
 
   return (
     <>
-      <NavMenu isOpen={isOpen} />
+      <NavMenu
+        isOpen={isOpen}
+        closeNavMenu={closeNavMenu}
+        setIsOpen={setIsOpen}
+      />
       <ResponsiveNavToggle
         isOpen={isOpen}
         handleMenuToggle={handleMenuToggle}

--- a/components/ResponsiveNavToggle/ResponsiveNavToggle.jsx
+++ b/components/ResponsiveNavToggle/ResponsiveNavToggle.jsx
@@ -5,7 +5,7 @@ const ResponsiveNavToggle = ({ isOpen, handleMenuToggle }) => {
   return (
     <button
       type="button"
-      className={styles['nav-menu-toggle']}
+      className={`${styles['nav-menu-toggle']} nav-menu-click-outside-exception`}
       onClick={handleMenuToggle}
       aria-expanded={isOpen}
     >

--- a/hooks/useClickOutside.js
+++ b/hooks/useClickOutside.js
@@ -1,0 +1,47 @@
+import { useRef, useEffect } from 'react';
+
+/**
+ * Listens for click events occurring outside of the element to which domNodeRef is passed. On "click outside" of the referenced element, the handleClickOutside callback is executed.
+ * NOTE: if an element has the className '.click-outside-exception', on click it will not execute the handleClickOutside callback
+ 
+ * @param { Function } handleClickOutside - function to execute when user clicks outside of domNodeRef
+ * @param { String } [classNamePrefix] - a className prefix used to (more precisely) control when exceptions apply for a single instance/call of useClickOutside. Tip: for clarity, use a name that refers to the element to which domNodeRef is passed.
+ 
+ * @return { React.MutableRefObject } domNodeRef - handleClickOutside is executed on the element to which domNodeRef is passed as a ref prop 
+ */
+export default function useClickOutside(
+  handleClickOutside,
+  classNamePrefix = ''
+) {
+  // Create className that will exclude an element from click detection
+  const classNameSuffix = 'click-outside-exception';
+  const exceptionClassName = classNamePrefix.length
+    ? `${classNamePrefix}-${classNameSuffix}`
+    : classNameSuffix;
+
+  // To be passed to element that will listen for outside clicks
+  const domNodeRef = useRef();
+
+  useEffect(() => {
+    // Event handler
+    const handleMouseDown = (e) => {
+      // ignore elements with className of exceptionClassName
+      if (e.target.classList.contains(exceptionClassName)) return;
+
+      // e.target DOES NOT MATCH domNodeRef
+      if (domNodeRef.current && !domNodeRef.current.contains(e.target)) {
+        handleClickOutside();
+      }
+    };
+
+    // register event listener
+    document.addEventListener('mousedown', handleMouseDown, true);
+
+    // cleanup event listener
+    return () => {
+      document.removeEventListener('mousedown', handleMouseDown, true);
+    };
+  }, []);
+
+  return domNodeRef;
+}

--- a/utils/swiper.js
+++ b/utils/swiper.js
@@ -1,0 +1,18 @@
+/**
+ * Handles when the .swiper-no-swiping class is added | removed | toggled from any Swiper components rendered.
+ * NOTE: .swiper-no-swiping is a className defined by the Swiper JS library
+ 
+ * @param { "add" | "remove" | "toggle" } classListMethod - the string name of a method used to manipulate the .swiper-no-swiping class
+
+ * __Use Case:__
+
+ * When trying to detect clicks outside of the mobile NavMenu, the Swiper component's touch/drag (i.e. swiping) capability prevents the registering of clicks. As a result the menu does not close.
+ * In NavRoot component, when toggling or closing the mobile NavMenu, handleSwiperNoSwiping is used to toggle or remove (respectively) the .swiper-no-swiping className.
+ * This temporarily disables the swiping capability whilst the mobile NavMenu is open, thus enabling the ability to register the outside click.
+ */
+export const handleSwiperNoSwiping = (classListMethod) => {
+  const swipers = document.querySelectorAll('.swiper');
+  swipers.forEach((swiper) =>
+    swiper.classList[classListMethod]('swiper-no-swiping')
+  );
+};


### PR DESCRIPTION
- close on click of navigation link
- close on click outside of mobile NavMenu

- introduces the useClickOutside hook, used to execute a callback when a
  click outside of an element is detected
- introduces handleSwiperNoSwiping util, used to handle when the
  .swiper-no-swiping className is applied to Swiper JS components